### PR TITLE
Fix type exports, for use in projects that use typeResolution: bundler; Preferred for TS 5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "type": "module",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "dist/index.cjs",
   "unpkg": "dist/index.umd.js",


### PR DESCRIPTION
Please consider this fix. It allows a project to import this library if it is compiling moduleResolution set to "bundler". This allows the library to be used in modern project configurations
`tsconfig`
```
{
  "compilerOptions": {
      ...
      "moduleResolution": "bundler",
  }
}
```