### PR TITLE
chore: update `package.json` to allow newer node versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mistral-tokenizer-ts",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mistral-tokenizer-ts",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12"
@@ -27,7 +27,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "^20",
+        "node": ">=20",
         "yarn": "please-use-npm-instead"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mistral-tokenizer-ts",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "TS tokenizer for Mistral-based LLMs",
   "keywords": [
     "mistral",
@@ -65,7 +65,7 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": "^20",
+    "node": ">=20",
     "yarn": "please-use-npm-instead"
   }
 }


### PR DESCRIPTION
Currently, the `package.json` is pinned only `v20.x` but we should allow other compatible node versions.

I have run `npm ci && npm run build && npm run test` for `v21.7.3`, `v22.15.0`, `v23.11.1`, `v24.0.1` which all run successfully so this update should be safe.

Bumping project version to `2.2.1` as this doesn't make any code changes.